### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python
+from setuptools import setup, find_packages
 
-from distutils.core import setup
 
-setup(name='DX-Analytics',
-		version='0.1',
-		description='DX Analytics',
-		author='Dr. Yves Hilpisch',
-		author_email='dx@tpq.io',
-		url='http://dx-analytics.com/')
+setup(
+    name='dx',
+    version='0.1',
+    description='DX Analytics',
+    classifiers=[
+        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'Programming Language :: Python',
+    ],
+    author='Dr. Yves Hilpisch',
+    author_email='dx@tpq.io',
+    url='http://dx-analytics.com/',
+    license='AGPLv3+',
+    install_requires=[
+        'pandas-datareader',
+        'scipy',
+        'statsmodels',
+    ],
+    packages=find_packages(),
+)


### PR DESCRIPTION
In this PR we update the setup.py file to permit pip installation of dx tools as library, ex.: 

```bash
(env)$ pip install -d 1 -e git+ssh://git@github.com/yhilpisch/dx.git#egg=dx
```

*Note:* It does not manage any requirement yet.

It's a first step before it permit the distribution the dx lib as whell package on pypi and offer an easy install of this awsome lib, ex. (if universal):

```bash
(env)$ pip install wheel
(env)$ python setup.py bdist_wheel --universal upload
```
